### PR TITLE
add boardType argument

### DIFF
--- a/firmware/python/lcls2_pgp_pcie_apps/_DevRoot.py
+++ b/firmware/python/lcls2_pgp_pcie_apps/_DevRoot.py
@@ -35,6 +35,7 @@ class DevRoot(shared.Root):
                  dataVc         = 1,
                  pollEn         = True,  # Enable automatic polling registers
                  initRead       = True,  # Read all registers at start of the system
+                 pcieBoardType  = None,
                  useDdr         = False,
                  **kwargs):
 
@@ -70,13 +71,14 @@ class DevRoot(shared.Root):
 
         # Instantiate the top level Device and pass it the memory map
         self.add(pcieApp.PcieFpga(
-            name     = 'DevPcie',
-            memBase  = self.memMap,
-            pgp4     = pgp4,
-            enLclsI  = enLclsI,
-            enLclsII = enLclsII,
-            useDdr   = useDdr,
-            expand   = True,
+            name      = 'DevPcie',
+            memBase   = self.memMap,
+            pgp4      = pgp4,
+            enLclsI   = enLclsI,
+            enLclsII  = enLclsII,
+            useDdr    = useDdr,
+            boardType = pcieBoardType,
+            expand    = True,
         ))
 
         self.add(pr.LocalVariable(

--- a/firmware/python/lcls2_pgp_pcie_apps/_PcieFpga.py
+++ b/firmware/python/lcls2_pgp_pcie_apps/_PcieFpga.py
@@ -16,10 +16,11 @@ import surf.axi                as axi
 
 class PcieFpga(pr.Device):
     def __init__(self,
-                 pgp4     = False,
-                 enLclsI  = True,
-                 enLclsII = False,
-                 useDdr   = False,
+                 pgp4      = False,
+                 enLclsI   = True,
+                 enLclsII  = False,
+                 useDdr    = False,
+                 boardType = None,
                  **kwargs):
         super().__init__(**kwargs)
 
@@ -27,6 +28,7 @@ class PcieFpga(pr.Device):
         self.add(pcie.AxiPcieCore(
             offset      = 0x0000_0000,
             numDmaLanes = 4,
+            boardType   = boardType,
             expand      = False,
         ))
 

--- a/software/scripts/devGui.py
+++ b/software/scripts/devGui.py
@@ -116,6 +116,14 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--pcieBoardType",
+        type     = str,
+        required = False,
+        default  = None,
+        help     = "define the type of PCIe card, used to select I2C mapping. Options: [None or SlacPgpCardG4 or XilinxKcu1500 or XilinxVariumC1100]",
+    )
+
+    parser.add_argument(
         "--serverPort",
         type     = int,
         required = False,
@@ -184,6 +192,7 @@ if __name__ == "__main__":
             yamlFileLclsII = args.yamlFileLclsII,
             startupMode    = args.startupMode,
             standAloneMode = args.standAloneMode,
+            pcieBoardType  = args.pcieBoardType,
             useDdr         = args.ddr,
         ) as root:
 


### PR DESCRIPTION
Add boardType argument in the devGui. Using https://github.com/slaclab/cameralink-gateway/ as a template.

- https://github.com/slaclab/cameralink-gateway/blob/master/software/scripts/devGui.py#L138
- https://github.com/slaclab/cameralink-gateway/blob/master/software/scripts/devGui.py#L220

- https://github.com/slaclab/cameralink-gateway/blob/master/firmware/python/cameralink_gateway/_ClinkDevRoot.py#L53
- https://github.com/slaclab/cameralink-gateway/blob/master/firmware/python/cameralink_gateway/_ClinkDevRoot.py#L105

- https://github.com/slaclab/cameralink-gateway/blob/master/firmware/python/cameralink_gateway/_ClinkPcieFpga.py#L31

which point to:

- https://github.com/slaclab/axi-pcie-core/blob/d1a83aa3a31e35d05d47084dd94b1f7be73b935f/python/axipcie/_AxiPcieCore.py#L30
- https://github.com/slaclab/axi-pcie-core/blob/d1a83aa3a31e35d05d47084dd94b1f7be73b935f/python/axipcie/_AxiPcieCore.py#L96-L148